### PR TITLE
Bump Rubocop version to incorporate fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@ Shared Rake tasks for Aptible projects.
 
 ## Installation
 
-Add these lines to your application's Gemfile. The second line is necessary until bbatsov/rubocop@33ea0a0 is released.
+Add the following line to your application's Gemfile:
 
     gem 'aptible-tasks'
-    gem 'rubocop', github: 'bbatsov/rubocop'
 
 And then run `bundle install`.
 

--- a/aptible-tasks.gemspec
+++ b/aptible-tasks.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rake'
-  spec.add_dependency 'rubocop', '>= 0.15.0'
+  spec.add_dependency 'rubocop', '>= 0.16.0'
   spec.add_dependency 'rspec', '~> 2.0'
 
   spec.add_development_dependency 'bundler', '~> 1.3'

--- a/lib/aptible/tasks/version.rb
+++ b/lib/aptible/tasks/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Tasks
-    VERSION = '0.1.4'
+    VERSION = '0.2.0'
   end
 end


### PR DESCRIPTION
Notably, projects using `aptible-tasks` no longer need to specify an unreleased version of the `rubcop` gem.
