### PR TITLE
Allow aptible-tasks to work w/ either RSpec 2.x or 3.x

### DIFF
--- a/aptible-tasks.gemspec
+++ b/aptible-tasks.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rake'
   spec.add_dependency 'rubocop', '>= 0.23.0'
-  spec.add_dependency 'rspec', '>= 2.0.0'
-  spec.add_dependency 'rspec-its'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'rspec', '>= 3.0.0'
+  spec.add_development_dependency 'rspec-its'
 end

--- a/lib/aptible/tasks/version.rb
+++ b/lib/aptible/tasks/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Tasks
-    VERSION = '0.4.5'
+    VERSION = '0.5.0'
   end
 end


### PR DESCRIPTION
...(or no RSpec), by making it a development dependency.
