### PR TITLE
Pin rubocop to 0.30.0

### DIFF
--- a/aptible-tasks.gemspec
+++ b/aptible-tasks.gemspec
@@ -16,11 +16,11 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files`.split($RS)
-  spec.test_files    = spec.files.grep(/^spec\//)
+  spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rake'
-  spec.add_dependency 'rubocop', '>= 0.23.0'
+  spec.add_dependency 'rubocop', '= 0.30.0'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'pry'


### PR DESCRIPTION
The most recent sweetness build just picked up a bug in the Performance/Sample cop (https://github.com/bbatsov/rubocop/issues/1816) from 0.30.1, which fails the sweetness build. Let's pin rubocop to a known good version so that we're not continually picking up new cops and changes from patch versions without explicit updates to aptible-tasks.