### PR TITLE
Disable Style/NumericPredicate

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,7 +33,10 @@ ClassLength:
 
 HandleExceptions:
   Enabled: false
-  
+
+Style/NumericPredicate:
+  Enabled: false
+
 Style/BracesAroundHashParameters:
   EnforcedStyle: context_dependent
 


### PR DESCRIPTION
This cop recommends using `#positive?` over `> 0`, but the former is
only available in Ruby 2.3, which we practically don't use anywhere.

Enforcing comparisons is probably not a great idea since we do use
`#zero?` in some places (including `lib/aptible/tasks/rubocop.rb` in
this repo), so let's just disable it.

---

cc @fancyremarker @chasballew 