### PR TITLE
Disable Style/FrozenStringLiteralComment

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,9 @@ HandleExceptions:
 Style/NumericPredicate:
   Enabled: false
 
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 Style/BracesAroundHashParameters:
   EnforcedStyle: context_dependent
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,7 +33,10 @@ ClassLength:
 
 HandleExceptions:
   Enabled: false
-  
+
+Style/NumericPredicate:
+  Enabled: false
+
 Style/BracesAroundHashParameters:
   EnforcedStyle: context_dependent
 


### PR DESCRIPTION
We're not really upgrading to Ruby 3 right now... Let's revisit once
it's out.

cc @fancyremarker @chasballew 