### PR TITLE
Disable ModuleLength cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,9 @@ CyclomaticComplexity:
 MethodLength:
   Enabled: false
 
+ModuleLength:
+  Enabled: false
+
 ClassLength:
   Enabled: false
 


### PR DESCRIPTION
We already silence MethodLength and ClassLength, there's no real reason
to have an arbitrary distinction here.