### PR TITLE
Update Rubucop version and enforced style updates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,6 +46,9 @@ Style/FrozenStringLiteralComment:
 Style/BracesAroundHashParameters:
   EnforcedStyle: context_dependent
 
+Style/BlockLength:
+  ExcludedMethods: ['describe', 'context']
+
 AllCops:
   Include:
     - !ruby/regexp /\.rb$/

--- a/aptible-tasks.gemspec
+++ b/aptible-tasks.gemspec
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
@@ -20,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rake', '~> 10.0'
-  spec.add_dependency 'rubocop', '= 0.42.0'
+  spec.add_dependency 'rubocop', '~> 0.49.0'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'pry'

--- a/lib/aptible/tasks/rubocop.rb
+++ b/lib/aptible/tasks/rubocop.rb
@@ -26,7 +26,7 @@ module Aptible
 
       def run
         cli = ::RuboCop::CLI.new
-        result = cli.run(%W(-c #{config_file}))
+        result = cli.run(%W[-c #{config_file}])
         abort unless result.zero?
       end
     end

--- a/lib/aptible/tasks/version.rb
+++ b/lib/aptible/tasks/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Tasks
-    VERSION = '0.5.8'.freeze
+    VERSION = '0.5.9'.freeze
   end
 end

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -1,2 +1,2 @@
 desc 'Run all continuous integration tasks'
-task ci: [:rubocop, :spec]
+task ci: %i[rubocop spec]


### PR DESCRIPTION
This will allow dependent projects to update and remove a security warning based on the use of rubocop v 0.42.
- style updates related to the updated rubocop version
- update rubocop.yml to exclude the Blocklength cop from `describe` and `context` rspec blocks (https://stackoverflow.com/questions/40934345/rubocop-25-line-block-size-and-rspec-tests)
- bump version
  