### PR TITLE
Relax Rake dependency

### DIFF
--- a/aptible-tasks.gemspec
+++ b/aptible-tasks.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rake', '~> 10.0'
+  spec.add_dependency 'rake', '>= 10', '< 13.0'
   spec.add_dependency 'rubocop', '= 0.42.0'
 
   spec.add_development_dependency 'bundler', '~> 1.3'


### PR DESCRIPTION
Rake doesn't really use semver, so pinning to 10.0 causes conflicts with
other gems. This fixes that.

---

cc @fancyremarker 