### PR TITLE
Bump rubocop to 0.62.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,6 +46,34 @@ Style/FrozenStringLiteralComment:
 Style/BracesAroundHashParameters:
   EnforcedStyle: context_dependent
 
+Style/SymbolArray:
+  Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false
+
+Lint/UnneededCopDisableDirective:
+  Enabled: false
+
+Lint/UnneededCopEnableDirective:
+  Enabled: false
+
+Lint/EmptyWhen:
+  Enabled: false
+
+Naming/UncommunicativeMethodParamName:
+  Enabled: false
+
+Style/ExpandPathArguments:
+  Enabled: false
+
+Style/EmptyMethod:
+  EnforcedStyle: 'expanded'
+
+Style/MixinUsage:
+  Enabled: false
+
+
 AllCops:
   Include:
     - !ruby/regexp /\.rb$/

--- a/aptible-tasks.gemspec
+++ b/aptible-tasks.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rake', '>= 10', '< 13.0'
-  spec.add_dependency 'rubocop', '= 0.42.0'
+  spec.add_dependency 'rubocop', '= 0.62.0'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'pry'


### PR DESCRIPTION
This updates rubocop so it can work with Ruby 2.5 code bases, and
disables a number of cops that were introduced since then to ease
adoption (and to remove a number of cops we don't care about).

---

cc @fancyremarker 