### PR TITLE
Increase max line length

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,10 @@ Style/SymbolArray:
 Metrics/BlockLength:
   Enabled: false
 
+Metrics/LineLength:
+  Enabled: true
+  Max: 100
+
 Lint/UnneededCopDisableDirective:
   Enabled: false
 


### PR DESCRIPTION
I'd like to suggest we increase rubocop's max line length to 100 lines (I'd also be happy to go to 120 :P )

I found I needed to do a lot of gymnastics to get lines down to under 80 in some cases, since we have verbose class names. Linus Torvalds has also recently [spoken against having any line length limits](https://www.theregister.com/2020/06/01/linux_5_7/#:~:text=Linux%20kernel%20overlord%20Linus%20Torvalds,a%20thing%20of%20the%20past.)

What do you all think?

cc/ @robertfairhead @aguilinger 