### PR TITLE
Bump version, new line length

### DIFF
--- a/lib/aptible/tasks/version.rb
+++ b/lib/aptible/tasks/version.rb
@@ -1,5 +1,5 @@
 module Aptible
   module Tasks
-    VERSION = '0.6.0'.freeze
+    VERSION = '0.6.1'.freeze
   end
 end


### PR DESCRIPTION
Could we publish a new version to take advantage of the new extended line length rule in rubocop?